### PR TITLE
feat: add channel taken and channel enumeration endpoints

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -8,6 +8,9 @@ use {
     url::Url,
 };
 
+pub const ADDRESS_KEY: &str = "address";
+pub const CHANNEL_KEY: &str = "channel";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetAuth {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,6 +2,7 @@ use {axum::http::StatusCode, serde_json::json};
 
 pub mod auth;
 pub mod channel;
+pub mod wallet;
 
 /// Utility function for mapping any error into a `500 Internal Server Error`
 /// response.

--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -1,0 +1,44 @@
+use {
+    crate::{model::ADDRESS_KEY, routes::internal_error, AppState},
+    anyhow::anyhow,
+    axum::{
+        extract::{Path, State},
+        http::StatusCode,
+        response::IntoResponse,
+    },
+    bb8_redis::redis::AsyncCommands,
+    serde_json::json,
+};
+
+pub async fn get_channels(
+    state: State<AppState>,
+    Path(address): Path<String>,
+) -> impl IntoResponse {
+    let address = match address.parse::<ethers::types::Address>() {
+        Ok(address) => address,
+        Err(err) => {
+            tracing::error!("Error parsing address: {:?}", err);
+            return internal_error(anyhow!(err));
+        }
+    };
+
+    tracing::info!("get channels for address {}", address);
+
+    let key = format!("{}:{}", ADDRESS_KEY, address);
+
+    let channels: Vec<String> = match state.pool.get().await {
+        Ok(mut conn) => match conn.smembers::<&str, Vec<String>>(&key).await {
+            Ok(content) => content,
+            Err(err) => {
+                tracing::error!("Error getting content for address {}: {:?}", address, err);
+                vec![]
+            }
+        },
+        Err(err) => {
+            tracing::error!("Error getting connection from pool: {:?}", err);
+            vec![]
+        }
+    };
+
+    (StatusCode::OK, json!({ "channels": channels }).to_string())
+}


### PR DESCRIPTION
 - new `/channel/:channel/taken` endpoint which returns `{taken: false}` or `{taken: true}` based on the passed channel name.
 - new `/wallet/:address/channels` endpoint which returns an array of channel names owned by the passed wallet address
     - note: an empty array is returned if the wallet owns no channels