### PR TITLE
feat: add allowed_origins env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,10 +152,10 @@ dependencies = [
  "redis",
  "regex",
  "reqwest 0.12.5",
- "reqwest-eventsource",
  "serde",
  "serde_json",
  "siwe",
+ "test-log",
  "tokio",
  "tokio-stream",
  "tower",
@@ -1008,6 +1008,27 @@ dependencies = [
  "serde",
  "sha3",
  "zeroize",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -3006,12 +3027,10 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg 0.50.0",
@@ -3060,22 +3079,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "winreg 0.52.0",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f529a5ff327743addc322af460761dff5b50e0c826b9e6ac44c3195c50bb2026"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest 0.11.27",
- "thiserror",
 ]
 
 [[package]]
@@ -3797,6 +3800,28 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ siwe = { version = "0.6", features = ["serde", "ethers"] }
 
 [dev-dependencies]
 eventsource-stream = "0.2"
-reqwest-eventsource = "0.5"
+test-log = {version = "0.2.16", features = ["trace"]}

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,6 +18,10 @@ pub struct Args {
     /// Secret key for JWT
     #[arg(long, env)]
     pub jwt_secret: SecretString,
+
+    /// Optional list of extra allowed origins
+    #[arg(long, env)]
+    pub allowed_origins: Option<Vec<String>>,
 }
 
 impl Args {

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,9 @@
-use {crate::utils::secret_string::SecretString, anyhow::Result, clap::Parser};
+use {
+    crate::utils::secret_string::SecretString,
+    anyhow::Result,
+    axum::http::HeaderValue,
+    clap::Parser,
+};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -20,8 +25,8 @@ pub struct Args {
     pub jwt_secret: SecretString,
 
     /// Optional list of extra allowed origins
-    #[arg(long, env)]
-    pub allowed_origins: Option<Vec<String>>,
+    #[arg(long, env, use_value_delimiter(true), value_delimiter(','))]
+    pub allowed_origins: Option<Vec<HeaderValue>>,
 }
 
 impl Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,13 @@ mod model;
 mod routes;
 mod utils;
 
+const ALLOWED_ORIGINS: &[&str] = &[
+    "http://localhost:5173",                          // local development
+    "https://macaw-resolved-arguably.ngrok-free.app", // ngrok
+    "https://gentle-flea-officially.ngrok-free.app",  // ngrok
+    "https://view.art",                               // production
+];
+
 #[derive(Clone)]
 struct AppState {
     pool: Pool<RedisConnectionManager>,
@@ -68,13 +75,23 @@ async fn main() -> Result<()> {
 
     let changes = Changes::new();
 
+    let allowed_origins = ALLOWED_ORIGINS
+        .iter()
+        .map(|origin| origin.to_string())
+        .chain(args.allowed_origins.unwrap_or_default())
+        .map(|origin| origin.parse::<HeaderValue>().unwrap())
+        .collect::<Vec<_>>();
+
     // build our application
-    let app = app(AppState {
-        pool,
-        changes,
-        provider,
-        keys,
-    });
+    let app = app(
+        allowed_origins,
+        AppState {
+            pool,
+            changes,
+            provider,
+            keys,
+        },
+    );
 
     // run it
     let listener =
@@ -89,7 +106,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn app(state: AppState) -> Router {
+fn app(allowed_origins: Vec<HeaderValue>, state: AppState) -> Router {
     let keys = state.keys.clone();
     // build our application with a route
     Router::new().nest(
@@ -114,16 +131,7 @@ fn app(state: AppState) -> Router {
             .layer(Extension(keys))
             .layer(
                 CorsLayer::new()
-                    .allow_origin([
-                        "http://localhost:5173".parse::<HeaderValue>().unwrap(),
-                        "https://macaw-resolved-arguably.ngrok-free.app"
-                            .parse::<HeaderValue>()
-                            .unwrap(),
-                        "https://gentle-flea-officially.ngrok-free.app"
-                            .parse::<HeaderValue>()
-                            .unwrap(),
-                        "https://view.art".parse::<HeaderValue>().unwrap(),
-                    ])
+                    .allow_origin(allowed_origins)
                     .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
                     .allow_headers([header::ACCEPT, header::CONTENT_TYPE, header::AUTHORIZATION]),
             )
@@ -183,12 +191,15 @@ mod tests {
         tokio::spawn(async {
             axum::serve(
                 listener,
-                app(AppState {
-                    pool,
-                    changes,
-                    provider,
-                    keys: Keys::new(String::from(JWT_SECRET).as_bytes()),
-                }),
+                app(
+                    vec![],
+                    AppState {
+                        pool,
+                        changes,
+                        provider,
+                        keys: Keys::new(String::from(JWT_SECRET).as_bytes()),
+                    },
+                ),
             )
             .await
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,11 +75,10 @@ async fn main() -> Result<()> {
 
     let changes = Changes::new();
 
-    let allowed_origins = ALLOWED_ORIGINS
+    let allowed_origins: Vec<HeaderValue> = ALLOWED_ORIGINS
         .iter()
-        .map(|origin| origin.to_string())
-        .chain(args.allowed_origins.unwrap_or_default())
         .map(|origin| origin.parse::<HeaderValue>().unwrap())
+        .chain(args.allowed_origins.unwrap_or_default())
         .collect::<Vec<_>>();
 
     // build our application

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,7 @@ mod tests {
         chrono::{SecondsFormat, Utc},
         ethers::{
             signers::{Signer, Wallet},
+            types::Bytes,
             utils::to_checksum,
         },
         eventsource_stream::Eventsource,
@@ -159,7 +160,7 @@ mod tests {
     };
 
     const REDIS_URL: &str = "redis://localhost:6379";
-    const BASE_RPC_URL: &str = "https://base.drpc.org";
+    const BASE_RPC_URL: &str = "https://mainnet.base.org";
     const JWT_SECRET: &str = "secret";
 
     /// A helper function that spawns our application in the background
@@ -207,7 +208,7 @@ mod tests {
         format!("http://{}:{}", host, port)
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn integration_test() {
         let listening_url = spawn_app("127.0.0.1").await;
 
@@ -420,11 +421,12 @@ Issued At: {}"#,
         );
         let message: Message = msg.parse().unwrap();
 
-        let signature = wallet
+        let signature: Bytes = wallet
             .sign_message(message.to_string())
             .await
             .unwrap()
-            .to_string();
+            .to_vec()
+            .into();
 
         let authorization = reqwest::Client::new()
             .post(&format!("{}/v1/auth", listening_url))

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,7 +2,7 @@ use {
     crate::caip::asset_id::AssetId,
     bb8_redis::redis::{FromRedisValue, RedisError, RedisResult, Value},
     chrono::{DateTime, Utc},
-    ethers::types::Address,
+    ethers::types::{Address, Bytes},
     serde::{Deserialize, Serialize},
     siwe::Message,
     url::Url,
@@ -21,7 +21,7 @@ pub struct GetAuth {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VerifyAuth {
     pub message: Message,
-    pub signature: String,
+    pub signature: Bytes,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
 - Add extra allowed origins by setting the `ALLOWED_ORIGINS` environment variable. This accepts an array of URLs.
 - e.g. `ALLOWED_ORIGINS="http://vercel.app"` or `ALLOWED_ORIGINS="http://vercel.app,http://test.app"`