### PR TITLE
Reintroduce support for Ethers in channel lookup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ jsonwebtoken = "8.0"
 
 # crypto
 alloy = { version = "0.3", features = ["full"] }
+ethers = { version = "2.0", features = ["rustls"] }
 siwe = { version = "0.6", features = ["serde"] }
 erc6492 = { git = "https://github.com/devanoneth/erc6492" }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,6 +3,7 @@ use {
     alloy::primitives::{Address, Bytes},
     bb8_redis::redis::{FromRedisValue, RedisError, RedisResult, Value},
     chrono::{DateTime, Utc},
+    ethers::types::Address,
     serde::{Deserialize, Serialize},
     siwe::Message,
     url::Url,

--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -1,6 +1,6 @@
 use {
-    crate::{model::ADDRESS_KEY, AppState},
-    alloy::primitives::Address,
+    crate::{model::ADDRESS_KEY, routes::internal_error, AppState},
+    anyhow::anyhow,
     axum::{
         extract::{Path, State},
         http::StatusCode,
@@ -8,12 +8,39 @@ use {
     },
     bb8_redis::redis::AsyncCommands,
     serde_json::json,
+    alloy::primitives::Address,
 };
+
+fn parse_truncated_address(address: &str) -> Result<Address, anyhow::Error> {
+    if address.len() == 42 {
+        // Full address, parse normally
+        Address::parse_checksummed(address, None).map_err(|e| anyhow!(e))
+    } else if address.len() == 14 && address.starts_with("0x") && address.contains("...") {
+        // Truncated address, reconstruct and parse
+        let parts: Vec<&str> = address.split("...").collect();
+        if parts.len() != 2 || parts[0].len() != 6 || parts[1].len() != 4 {
+            return Err(anyhow!("Invalid truncated address format"));
+        }
+        let full_address = format!("0x{}00000000000000000000{}", &parts[0][2..], parts[1]);
+        Address::parse_checksummed(&full_address, None).map_err(|e| anyhow!(e))
+    } else {
+        Err(anyhow!("Invalid address format"))
+    }
+}
 
 pub async fn get_channels(
     state: State<AppState>,
-    Path(address): Path<Address>,
+    Path(address): Path<String>,
 ) -> impl IntoResponse {
+    let address = match parse_truncated_address(&address) {
+        Ok(address) => address,
+        Err(err) => {
+            tracing::error!("Error parsing address: {:?}", err);
+            return internal_error(anyhow!(err));
+        }
+    };
+
+
     tracing::info!("get channels for address {}", address);
 
     let key = format!("{}:{}", ADDRESS_KEY, address);

--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -11,35 +11,20 @@ use {
     alloy::primitives::Address,
 };
 
-fn parse_truncated_address(address: &str) -> Result<Address, anyhow::Error> {
-    if address.len() == 42 {
-        // Full address, parse normally
-        Address::parse_checksummed(address, None).map_err(|e| anyhow!(e))
-    } else if address.len() == 14 && address.starts_with("0x") && address.contains("...") {
-        // Truncated address, reconstruct and parse
-        let parts: Vec<&str> = address.split("...").collect();
-        if parts.len() != 2 || parts[0].len() != 6 || parts[1].len() != 4 {
-            return Err(anyhow!("Invalid truncated address format"));
-        }
-        let full_address = format!("0x{}00000000000000000000{}", &parts[0][2..], parts[1]);
-        Address::parse_checksummed(&full_address, None).map_err(|e| anyhow!(e))
-    } else {
-        Err(anyhow!("Invalid address format"))
-    }
-}
-
 pub async fn get_channels(
     state: State<AppState>,
     Path(address): Path<String>,
 ) -> impl IntoResponse {
-    let address = match parse_truncated_address(&address) {
+    let address = match Address::parse_checksummed(&address, None) {
         Ok(address) => address,
-        Err(err) => {
-            tracing::error!("Error parsing address: {:?}", err);
-            return internal_error(anyhow!(err));
-        }
+        Err(_) => match address.parse::<ethers::types::Address>() {
+            Ok(eth_address) => Address::from_slice(eth_address.as_bytes()),
+            Err(err) => {
+                tracing::error!("Error parsing address: {:?}", err);
+                return internal_error(anyhow!(err));
+            }
+        },
     };
-
 
     tracing::info!("get channels for address {}", address);
 


### PR DESCRIPTION
The upgrade to alloy broke some of our legacy addresses. This PR reintroduces Ethers for type checking in the wallet lookup route.