### PR TITLE
Support sharing channels

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,7 @@ mod tests {
             EmptyChannelContent,
             GetAuth,
             Item,
+            SharedWith,
             Status,
             VerifyAuth,
         },
@@ -277,7 +278,7 @@ mod tests {
                             let result = reqwest::Client::new()
                                 .post(format!("{}/v1/channel/test", listening_url))
                                 .header("User-Agent", "integration_test")
-                                .json(&ChannelContent::ChannelContentV3 {
+                                .json(&ChannelContent::ChannelContentV4 {
                                     items: vec![Item {
                                         id: "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769".parse::<AssetId>().unwrap(),
                                         title: "test".to_string(),
@@ -295,6 +296,7 @@ mod tests {
                                         show_attribution: false,
                                         show_border: false,
                                     },
+                                    shared_with: vec![],
                                     status: Status {
                                         item: 0,
                                         at: Utc::now(),
@@ -311,7 +313,7 @@ mod tests {
                                 .post(format!("{}/v1/channel/test", listening_url))
                                 .header("User-Agent", "integration_test")
                                 .header("Authorization", format!("Bearer {}", authorization))
-                                .json(&ChannelContent::ChannelContentV3 {
+                                .json(&ChannelContent::ChannelContentV4 {
                                     items: vec![Item {
                                         id: "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769".parse::<AssetId>().unwrap(),
                                         title: "test".to_string(),
@@ -329,6 +331,7 @@ mod tests {
                                         show_attribution: false,
                                         show_border: false,
                                     },
+                                    shared_with: vec![],
                                     status: Status {
                                         item: 0,
                                         at: Utc::now(),
@@ -343,9 +346,10 @@ mod tests {
                             let content =
                                 serde_json::from_str::<ChannelContent>(&event.data).unwrap();
 
-                            if let ChannelContent::ChannelContentV3 {
+                            if let ChannelContent::ChannelContentV4 {
                                 items,
                                 display,
+                                shared_with,
                                 status,
                             } = content
                             {
@@ -358,9 +362,10 @@ mod tests {
                                 assert!(!display.show_attribution);
                                 assert!(!display.show_border);
                                 assert!(status.item == 0);
+                                assert!(shared_with.is_empty());
                                 assert!(status.action == Action::Played);
                             } else {
-                                panic!("Expected ChannelContentV3 variant");
+                                panic!("Expected ChannelContentV4 variant");
                             }
 
                             // check if channel is taken
@@ -400,7 +405,7 @@ mod tests {
                                 .post(format!("{}/v1/channel/test", listening_url))
                                 .header("User-Agent", "integration_test")
                                 .header("Authorization", format!("Bearer {}", authorization))
-                                .json(&ChannelContent::ChannelContentV3 {
+                                .json(&ChannelContent::ChannelContentV4 {
                                     items: vec![Item {
                                         id: "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769".parse::<AssetId>().unwrap(),
                                         title: "test".to_string(),
@@ -418,6 +423,7 @@ mod tests {
                                         show_attribution: false,
                                         show_border: false,
                                     },
+                                    shared_with: vec![],
                                     status: Status {
                                         item: 1,
                                         at: Utc::now(),
@@ -432,9 +438,10 @@ mod tests {
                             let content =
                                 serde_json::from_str::<ChannelContent>(&event.data).unwrap();
 
-                            if let ChannelContent::ChannelContentV3 {
+                            if let ChannelContent::ChannelContentV4 {
                                 items,
                                 display,
+                                shared_with,
                                 status,
                             } = content
                             {
@@ -445,9 +452,10 @@ mod tests {
                                 assert!(!display.show_attribution);
                                 assert!(!display.show_border);
                                 assert!(status.item == 1);
+                                assert!(shared_with.is_empty());
                                 assert!(status.action == Action::Played);
                             } else {
-                                panic!("Expected ChannelContentV3 variant");
+                                panic!("Expected ChannelContentV4 variant");
                             }
                         }
                         _ => {
@@ -527,7 +535,7 @@ Issued At: {}"#,
             .post(format!("{}/v1/channel/test", listening_url))
             .header("User-Agent", "integration_test")
             .header("Authorization", format!("Bearer {}", authorization))
-            .json(&ChannelContent::ChannelContentV3 {
+            .json(&ChannelContent::ChannelContentV4 {
                 items: vec![Item {
                     id: "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769"
                         .parse::<AssetId>()
@@ -547,6 +555,7 @@ Issued At: {}"#,
                     show_attribution: false,
                     show_border: false,
                 },
+                shared_with: vec![],
                 status: Status {
                     item: 0,
                     at: Utc::now(),
@@ -563,7 +572,7 @@ Issued At: {}"#,
             .post(format!("{}/v1/channel/test-user", listening_url))
             .header("User-Agent", "integration_test")
             .header("Authorization", format!("Bearer {}", authorization))
-            .json(&ChannelContent::ChannelContentV3 {
+            .json(&ChannelContent::ChannelContentV4 {
                 items: vec![Item {
                     id: "eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769"
                         .parse::<AssetId>()
@@ -583,6 +592,7 @@ Issued At: {}"#,
                     show_attribution: false,
                     show_border: false,
                 },
+                shared_with: vec![],
                 status: Status {
                     item: 0,
                     at: Utc::now(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,6 @@ mod tests {
             EmptyChannelContent,
             GetAuth,
             Item,
-            SharedWith,
             Status,
             VerifyAuth,
         },

--- a/src/model.rs
+++ b/src/model.rs
@@ -45,7 +45,7 @@ pub enum ChannelContent {
         #[serde(default = "default_display")]
         display: Display,
         #[serde(default = "default_shared_with")]
-    shared_with: Vec<Address>,
+        shared_with: Vec<Address>,
         status: Status,
     },
     ChannelContentV3 {
@@ -73,49 +73,50 @@ impl ChannelContent {
             ChannelContent::ChannelContentV2 { items, .. } => items,
             ChannelContent::ChannelContentV3 { items, .. } => items,
             ChannelContent::ChannelContentV4 { items, .. } => items,
-    }
+        }
 
-    pub fn v4(self) -> ChannelContent {
-        match self {
-            ChannelContent::ChannelContentV1 { items, played } => {
-                ChannelContent::ChannelContentV3 {
-                    items,
-                    display: default_display(),
-                    status: Status {
-                        item: played.item,
-                        at: played.at,
-                        action: Action::Played,
-                    },
+        pub fn v4(self) -> ChannelContent {
+            match self {
+                ChannelContent::ChannelContentV1 { items, played } => {
+                    ChannelContent::ChannelContentV3 {
+                        items,
+                        display: default_display(),
+                        status: Status {
+                            item: played.item,
+                            at: played.at,
+                            action: Action::Played,
+                        },
+                    }
                 }
-            }
-            ChannelContent::ChannelContentV2 {
-                items,
-                item_duration,
-                status,
-            } => {
-                let mut default_display = default_display();
-                default_display.item_duration = item_duration;
-                ChannelContent::ChannelContentV3 {
+                ChannelContent::ChannelContentV2 {
                     items,
-                    display: default_display,
+                    item_duration,
                     status,
+                } => {
+                    let mut default_display = default_display();
+                    default_display.item_duration = item_duration;
+                    ChannelContent::ChannelContentV3 {
+                        items,
+                        display: default_display,
+                        status,
+                    }
                 }
-            }
-            ChannelContent::ChannelContentV3 {
-                items,
-                display, 
-                status
-            } => {
-                let mut default_shared_with = default_shared_with();
-                default_shared_with.extend(shared_with);
-                ChannelContent::ChannelContentV4 {
+                ChannelContent::ChannelContentV3 {
                     items,
                     display,
-                    shared_with: default_shared_with,
                     status,
+                } => {
+                    let mut default_shared_with = default_shared_with();
+                    default_shared_with.extend(shared_with);
+                    ChannelContent::ChannelContentV4 {
+                        items,
+                        display,
+                        shared_with: default_shared_with,
+                        status,
+                    }
                 }
+                content @ ChannelContent::ChannelContentV4 { .. } => content,
             }
-            content @ ChannelContent::ChannelContentV4 { .. } => content,
         }
     }
 }
@@ -228,9 +229,10 @@ mod tests {
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
-    struct ChannelContentV3Test {
+    struct ChannelContentV4Test {
         items: Vec<Item>,
         display: Display,
+        shared_with: Vec<Address>,
         status: Status,
     }
 
@@ -241,8 +243,8 @@ mod tests {
     /// channel content you want to test and then run:
     /// cargo test test_channel_content_v3_serialization -- --ignored
     /// --nocapture
-    fn test_channel_content_v3_serialization() {
+    fn test_channel_content_v4_serialization() {
         let channel_content = include_str!("../test/test_channel_content.json");
-        let _: ChannelContentV3Test = serde_json::from_str(channel_content).unwrap();
+        let _: ChannelContentV4Test = serde_json::from_str(channel_content).unwrap();
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -45,7 +45,7 @@ pub enum ChannelContent {
         #[serde(default = "default_display")]
         display: Display,
         #[serde(default = "default_shared_with")]
-        shared_with: Vec<Address>,
+        shared_with: Vec<String>,
         status: Status,
     },
     ChannelContentV3 {
@@ -121,7 +121,7 @@ impl ChannelContent {
 
 // ChannelContentV4
 
-fn default_shared_with() -> Vec<Address> {
+fn default_shared_with() -> Vec<String> {
     vec![]
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -45,7 +45,7 @@ pub enum ChannelContent {
         #[serde(default = "default_display")]
         display: Display,
         #[serde(default = "default_shared_with")]
-        shared_with: Vec<String>,
+        shared_with: Vec<Address>,
         status: Status,
     },
     ChannelContentV3 {
@@ -121,7 +121,7 @@ impl ChannelContent {
 
 // ChannelContentV4
 
-fn default_shared_with() -> Vec<String> {
+fn default_shared_with() -> Vec<Address> {
     vec![]
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -106,14 +106,12 @@ impl ChannelContent {
                 items,
                 display,
                 status,
-            } => {
-                ChannelContent::ChannelContentV4 {
-                    items,
-                    display,
-                    shared_with: default_shared_with(),
-                    status,
-                }
-            }
+            } => ChannelContent::ChannelContentV4 {
+                items,
+                display,
+                shared_with: default_shared_with(),
+                status,
+            },
             content @ ChannelContent::ChannelContentV4 { .. } => content,
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -40,6 +40,14 @@ pub struct Item {
 #[serde(untagged)]
 #[serde(rename_all_fields = "camelCase")]
 pub enum ChannelContent {
+    ChannelContentV4 {
+        items: Vec<Item>,
+        #[serde(default = "default_display")]
+        display: Display,
+        #[serde(default = "default_shared_with")]
+    shared_with: Vec<Address>,
+        status: Status,
+    },
     ChannelContentV3 {
         items: Vec<Item>,
         #[serde(default = "default_display")]
@@ -64,10 +72,10 @@ impl ChannelContent {
             ChannelContent::ChannelContentV1 { items, .. } => items,
             ChannelContent::ChannelContentV2 { items, .. } => items,
             ChannelContent::ChannelContentV3 { items, .. } => items,
-        }
+            ChannelContent::ChannelContentV4 { items, .. } => items,
     }
 
-    pub fn v3(self) -> ChannelContent {
+    pub fn v4(self) -> ChannelContent {
         match self {
             ChannelContent::ChannelContentV1 { items, played } => {
                 ChannelContent::ChannelContentV3 {
@@ -93,9 +101,29 @@ impl ChannelContent {
                     status,
                 }
             }
-            content @ ChannelContent::ChannelContentV3 { .. } => content,
+            ChannelContent::ChannelContentV3 {
+                items,
+                display, 
+                status
+            } => {
+                let mut default_shared_with = default_shared_with();
+                default_shared_with.extend(shared_with);
+                ChannelContent::ChannelContentV4 {
+                    items,
+                    display,
+                    shared_with: default_shared_with,
+                    status,
+                }
+            }
+            content @ ChannelContent::ChannelContentV4 { .. } => content,
         }
     }
+}
+
+// ChannelContentV4
+
+fn default_shared_with() -> Vec<Address> {
+    vec![]
 }
 
 // ChannelContentV3

--- a/src/model.rs
+++ b/src/model.rs
@@ -74,49 +74,47 @@ impl ChannelContent {
             ChannelContent::ChannelContentV3 { items, .. } => items,
             ChannelContent::ChannelContentV4 { items, .. } => items,
         }
+    }
 
-        pub fn v4(self) -> ChannelContent {
-            match self {
-                ChannelContent::ChannelContentV1 { items, played } => {
-                    ChannelContent::ChannelContentV3 {
-                        items,
-                        display: default_display(),
-                        status: Status {
-                            item: played.item,
-                            at: played.at,
-                            action: Action::Played,
-                        },
-                    }
-                }
-                ChannelContent::ChannelContentV2 {
-                    items,
-                    item_duration,
-                    status,
-                } => {
-                    let mut default_display = default_display();
-                    default_display.item_duration = item_duration;
-                    ChannelContent::ChannelContentV3 {
-                        items,
-                        display: default_display,
-                        status,
-                    }
-                }
+    pub fn v4(self) -> ChannelContent {
+        match self {
+            ChannelContent::ChannelContentV1 { items, played } => {
                 ChannelContent::ChannelContentV3 {
                     items,
-                    display,
-                    status,
-                } => {
-                    let mut default_shared_with = default_shared_with();
-                    default_shared_with.extend(shared_with);
-                    ChannelContent::ChannelContentV4 {
-                        items,
-                        display,
-                        shared_with: default_shared_with,
-                        status,
-                    }
+                    display: default_display(),
+                    status: Status {
+                        item: played.item,
+                        at: played.at,
+                        action: Action::Played,
+                    },
                 }
-                content @ ChannelContent::ChannelContentV4 { .. } => content,
             }
+            ChannelContent::ChannelContentV2 {
+                items,
+                item_duration,
+                status,
+            } => {
+                let mut default_display = default_display();
+                default_display.item_duration = item_duration;
+                ChannelContent::ChannelContentV3 {
+                    items,
+                    display: default_display,
+                    status,
+                }
+            }
+            ChannelContent::ChannelContentV3 {
+                items,
+                display,
+                status,
+            } => {
+                ChannelContent::ChannelContentV4 {
+                    items,
+                    display,
+                    shared_with: default_shared_with(),
+                    status,
+                }
+            }
+            content @ ChannelContent::ChannelContentV4 { .. } => content,
         }
     }
 }


### PR DESCRIPTION
Should be merged with [front-end pr here](https://github.com/loudsqueak/view.art/pull/363)

- Create and leverage `ChannelContentV4` with added `shared_with` property
- Support setting `shared_with` when calling `set_channel`
- Update `set_channel` to also update `address` sets when a user is granted or revoked `share` access