### PR TITLE
Simplify top channel/item tracking

### DIFF
--- a/src/routes/stream.rs
+++ b/src/routes/stream.rs
@@ -256,7 +256,8 @@ async fn process_time_range(
 
     // Add the target to the list if it should be added
     if should_add_target {
-        conn.rpush(&params.top_targets_list_key, &params.target_count_key)
+        let _: () = conn
+            .rpush(&params.top_targets_list_key, &params.target_count_key)
             .await
             .map_err(|err| {
                 tracing::error!("Error adding target to list: {err:?}");

--- a/src/routes/stream.rs
+++ b/src/routes/stream.rs
@@ -243,8 +243,7 @@ async fn process_time_range(
         } else {
             params.top_targets_count - 1
         };
-        let _ = conn
-            .ltrim(&params.top_targets_list_key, 0, end_index as isize)
+        conn.ltrim(&params.top_targets_list_key, 0, end_index as isize)
             .await
             .map_err(|_| {
                 (

--- a/src/routes/stream.rs
+++ b/src/routes/stream.rs
@@ -96,7 +96,7 @@ pub async fn log_channel_view(
         // ("monthly", 30 * 24 * 60 * 60), // 30 days
     ];
 
-    let top_channels_count = if cfg!(test) { 5 } else { 5 };
+    let top_channels_count = if cfg!(test) { 5 } else { 15 };
 
     // Check if the channel exists
     check_target_exists(&mut conn, &channel_key).await?;
@@ -578,11 +578,10 @@ mod tests {
             assert_eq!(sorted_targets.len(), 5);
 
             // Assert pruned is not in sorted targets
-            let top_channel_1_key = "top_channels:weekly:test_channel_1";
             assert!(
                 !sorted_targets
                     .iter()
-                    .any(|(name, _)| name == &top_channel_1_key),
+                    .any(|(name, _)| name == "top_channels:weekly:test_channel_1"),
                 "test_channel_1 should not be in sorted targets"
             );
 
@@ -624,11 +623,10 @@ mod tests {
             assert_eq!(channel_view_count, "3");
 
             // Assert pruned is not in sorted targets
-            let top_channel_2_key = "top_channels:weekly:test_channel_2";
             assert!(
                 !sorted_targets
                     .iter()
-                    .any(|(name, _)| name == &top_channel_2_key),
+                    .any(|(name, _)| name == "top_channels:weekly:test_channel_2"),
                 "test_channel_2 should not be in sorted targets"
             );
             assert_eq!(sorted_targets.len(), 5);

--- a/src/routes/stream.rs
+++ b/src/routes/stream.rs
@@ -243,7 +243,8 @@ async fn process_time_range(
         } else {
             params.top_targets_count - 1
         };
-        conn.ltrim(&params.top_targets_list_key, 0, end_index as isize)
+        let _: () = conn
+            .ltrim(&params.top_targets_list_key, 0, end_index as isize)
             .await
             .map_err(|_| {
                 (

--- a/src/routes/stream.rs
+++ b/src/routes/stream.rs
@@ -243,7 +243,8 @@ async fn process_time_range(
         } else {
             params.top_targets_count - 1
         };
-        conn.ltrim(&params.top_targets_list_key, 0, end_index as isize)
+        let _ = conn
+            .ltrim(&params.top_targets_list_key, 0, end_index as isize)
             .await
             .map_err(|_| {
                 (

--- a/src/utils/keys.rs
+++ b/src/utils/keys.rs
@@ -42,16 +42,16 @@ pub fn top_channel_key(range: &str, channel: &str) -> String {
     format!("{}:{}:{}", TOP_CHANNEL_KEY, range, channel).to_ascii_lowercase()
 }
 
-pub fn all_top_channels_key(range: &str) -> String {
-    format!("{}:{}:*", TOP_CHANNEL_KEY, range).to_ascii_lowercase()
+pub fn top_channel_list_key(range: &str) -> String {
+    format!("{}:{}", TOP_CHANNEL_KEY, range).to_ascii_lowercase()
 }
 
 pub fn top_item_key(range: &str, item_caid: &str) -> String {
     format!("{}:{}:{}", TOP_ITEM_KEY, range, item_caid).to_ascii_lowercase()
 }
 
-pub fn all_top_items_key(range: &str) -> String {
-    format!("{}:{}:*", TOP_ITEM_KEY, range).to_ascii_lowercase()
+pub fn top_items_list_key(range: &str) -> String {
+    format!("{}:{}", TOP_ITEM_KEY, range).to_ascii_lowercase()
 }
 
 pub fn nonce_key(address: &Address, chain_id: u64) -> String {
@@ -151,12 +151,12 @@ mod tests {
     }
 
     #[test]
-    fn test_all_top_channels_key() {
-        let key = all_top_channels_key("daily");
-        assert_eq!(key, "top_channels:daily:*");
+    fn test_top_channel_list_key() {
+        let key = top_channel_list_key("daily");
+        assert_eq!(key, "top_channels:daily");
 
-        let key = all_top_channels_key("DAILY");
-        assert_eq!(key, "top_channels:daily:*");
+        let key = top_channel_list_key("DAILY");
+        assert_eq!(key, "top_channels:daily");
     }
 
     #[test]
@@ -169,12 +169,12 @@ mod tests {
     }
 
     #[test]
-    fn test_all_top_items_key() {
-        let key = all_top_items_key("daily");
-        assert_eq!(key, "top_items:daily:*");
+    fn test_top_items_list_key() {
+        let key = top_items_list_key("daily");
+        assert_eq!(key, "top_items:daily");
 
-        let key = all_top_items_key("DAILY");
-        assert_eq!(key, "top_items:daily:*");
+        let key = top_items_list_key("DAILY");
+        assert_eq!(key, "top_items:daily");
     }
 
     #[test]

--- a/src/utils/keys.rs
+++ b/src/utils/keys.rs
@@ -38,16 +38,8 @@ pub fn user_stream_key(user: &str, item_caid: &str) -> String {
     format!("{}:{}:{}", USER_STREAM_KEY, user, item_caid).to_ascii_lowercase()
 }
 
-pub fn top_channel_key(range: &str, channel: &str) -> String {
-    format!("{}:{}:{}", TOP_CHANNEL_KEY, range, channel).to_ascii_lowercase()
-}
-
 pub fn top_channel_list_key(range: &str) -> String {
     format!("{}:{}", TOP_CHANNEL_KEY, range).to_ascii_lowercase()
-}
-
-pub fn top_item_key(range: &str, item_caid: &str) -> String {
-    format!("{}:{}:{}", TOP_ITEM_KEY, range, item_caid).to_ascii_lowercase()
 }
 
 pub fn top_items_list_key(range: &str) -> String {
@@ -142,30 +134,12 @@ mod tests {
     }
 
     #[test]
-    fn test_top_channel_key() {
-        let key = top_channel_key("daily", "testchannel");
-        assert_eq!(key, "top_channels:daily:testchannel");
-
-        let key = top_channel_key("DAILY", "TESTCHANNEL");
-        assert_eq!(key, "top_channels:daily:testchannel");
-    }
-
-    #[test]
     fn test_top_channel_list_key() {
         let key = top_channel_list_key("daily");
         assert_eq!(key, "top_channels:daily");
 
         let key = top_channel_list_key("DAILY");
         assert_eq!(key, "top_channels:daily");
-    }
-
-    #[test]
-    fn test_top_item_key() {
-        let key = top_item_key("daily", "testitem");
-        assert_eq!(key, "top_items:daily:testitem");
-
-        let key = top_item_key("DAILY", "TESTITEM");
-        assert_eq!(key, "top_items:daily:testitem");
     }
 
     #[test]

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -30,6 +30,7 @@ pub async fn ts_incrby(
         })
 }
 
+#[cfg(test)]
 pub async fn ts_add(
     conn: &mut PooledConnection<'_, RedisConnectionManager>,
     key: &str,
@@ -56,6 +57,7 @@ pub trait TimeSeriesCommands: Send {
         timestamp: Option<i64>,
     ) -> Pin<Box<dyn Future<Output = RedisResult<()>> + Send + 'a>>;
 
+    #[cfg(test)]
     fn ts_add<'a>(
         &'a mut self,
         key: &'a str,
@@ -93,6 +95,7 @@ impl<T: ConnectionLike + Send> TimeSeriesCommands for T {
         })
     }
 
+    #[cfg(test)]
     fn ts_add<'a>(
         &'a mut self,
         key: &'a str,

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -2,7 +2,7 @@ use {
     axum::http::StatusCode,
     bb8::PooledConnection,
     bb8_redis::{
-        redis::{aio::ConnectionLike, AsyncCommands, Cmd, RedisResult},
+        redis::{aio::ConnectionLike, Cmd, RedisResult},
         RedisConnectionManager,
     },
     serde_json::json,
@@ -46,19 +46,6 @@ pub async fn ts_add(
                 json!({ "error": "Redis error while adding time series data" }).to_string(),
             )
         })
-}
-
-pub async fn delete(
-    conn: &mut PooledConnection<'_, RedisConnectionManager>,
-    key: &str,
-) -> Result<(), (StatusCode, String)> {
-    conn.del(key).await.map_err(|err| {
-        tracing::error!("Error deleting key {}: {:?}", key, err);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            json!({ "error": "Redis error while deleting key" }).to_string(),
-        )
-    })
 }
 
 pub trait TimeSeriesCommands: Send {


### PR DESCRIPTION
In an effort to reduce network loads, we are further simplifying the top channel/item tracking. See #39 

Changes:
- Data structure is changed from time series objects to list
- Reduce redundant lookup calls and data duplication
- Ensure rate limited requests aren't returned as bad requests